### PR TITLE
Add 'Enter' keybinding as 'newlineAndIndent'

### DIFF
--- a/jupyter_emacskeys/init.js
+++ b/jupyter_emacskeys/init.js
@@ -10,6 +10,8 @@ define([
         // all newly created cells will have them.
         var extraKeys = CodeMirror.keyMap.emacs;
 
+        if (!extraKeys["Enter"]) extraKeys["Enter"] = "newlineAndIndent";
+
         // override Ctrl-Y to not select the whole line, because I
         // don't like that feature
         var ctrl_y_super = extraKeys["Ctrl-Y"];


### PR DESCRIPTION
Hello, thank you for a great work!

In my environment, auto-indent does not work when I type Enter key.
I found that somehow `extraKeys["Enter"]` is not set then added it.
I'm not sure this problem occurs on other envs and whether this PR is necessary. please accept if you think it is.
thanks.